### PR TITLE
docs: reconcile AGENTS.md template with root project version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,15 @@
 # pkgskills (development version)
 
+* `use_agent()` template is reconciled with this package's `AGENTS.md` file (#59).
 * `tdd-workflow` skill now documents `stbl::expect_pkg_error_snapshot()` with an explicit `package` argument instead of a helper-defined version (#51).
 * Tests now use `stbl::expect_pkg_error_snapshot()` directly instead of a locally-defined wrapper; the `expect_pkg_error_snapshot()` definition has been removed from `tests/testthat/helper-expectations.R` (#50).
 * `use_skill_tdd_workflow()` no longer installs `helper-expectations.R` into the target project; `stbl::expect_pkg_error_snapshot()` is now used directly (#52).
-
 * `use_skill_r_code()` now installs a minimal `R/aaa-conditions.R` into the project when the file does not already exist (#48).
-
 * Internal coercion wrappers `.to_string()` and `.to_boolean()` replaced with direct `stbl::to_character_scalar()` and `stbl::to_lgl_scalar()` calls; `R/utils-coerce.R` removed (#46).
-
 * `use_github_copilot()` now writes workflow files byte-for-byte from the templates, preserving `${{ }}` GitHub Actions expressions that were previously corrupted by whisker rendering (#44).
 * `use_ai()` now works when called via `pkgskills::use_ai()` without first calling `library(pkgskills)` (#42).
 * `use_agent()` now accepts an `overwrite` argument (default `FALSE`) and errors if `AGENTS.md` already exists, consistent with other `use_*()` functions (#36).
 * All `use_*()` functions that accept `overwrite` now default to `FALSE` (#36).
-
 * `vignette("pkgskills")` now provides a complete "Get Started" guide covering terminology, `use_ai()` setup, skill descriptions, and issue-writing best practices (#31).
 * `use_ai()` sets up the full AI agent suite in a single call, installing `AGENTS.md`, the GitHub Copilot workflow, and all selected skills (#28).
 * `use_github_copilot()` installs a `copilot-setup-steps.yml` workflow and its companion reusable `install` action into `.github/workflows/` (#25).

--- a/inst/templates/AGENTS.md
+++ b/inst/templates/AGENTS.md
@@ -41,12 +41,17 @@ For any feature, fix, or refactor:
 5. **Implement** — minimal code to pass tests.
 6. **Refactor** — clean up, keep tests green.
 7. **Document** — document any new or changed exports.
-8. **Verify**: `devtools::check(error_on = "warning")`. Resolve warnings, errors, and NOTEs.
-9. **News** — add a bullet at the top of `NEWS.md` for user-facing changes.
+8. **Verify**: Run `devtools::test(reporter = "check")`, then `devtools::check(error_on = "warning")`. Resolve warnings, errors, and NOTEs.
+9. **News** — add bullet at top of `NEWS.md` (under dev heading):
+   - User-facing changes only. 1 line, end with `.`
+   - Present tense, positive framing, function names (backticks + `()`) near start: `` * `fn()` now accepts ... `` not `* Fixed ...`
+   - Issue/contributor before final period: `` * `fn()` now accepts ... (@user, #N). ``
+   - Get username: `gh api user --jq .login`
 
 ---
 
 ## General
 
 - R console: use `--quiet --vanilla`.
+- Always run `air format .` after generating R code.
 - Comments explain *why*, not *what*.

--- a/tests/testthat/_snaps/use_agent.md
+++ b/tests/testthat/_snaps/use_agent.md
@@ -1,4 +1,4 @@
-# use_agent() substitutes Package and Title into the template (#2)
+# use_agent() substitutes Package and Title into the template (#2, #59)
 
     Code
       writeLines(readLines(fs::path(proj_dir, "AGENTS.md")))
@@ -46,17 +46,22 @@
       5. **Implement** — minimal code to pass tests.
       6. **Refactor** — clean up, keep tests green.
       7. **Document** — document any new or changed exports.
-      8. **Verify**: `devtools::check(error_on = "warning")`. Resolve warnings, errors, and NOTEs.
-      9. **News** — add a bullet at the top of `NEWS.md` for user-facing changes.
+      8. **Verify**: Run `devtools::test(reporter = "check")`, then `devtools::check(error_on = "warning")`. Resolve warnings, errors, and NOTEs.
+      9. **News** — add bullet at top of `NEWS.md` (under dev heading):
+         - User-facing changes only. 1 line, end with `.`
+         - Present tense, positive framing, function names (backticks + `()`) near start: `` * `fn()` now accepts ... `` not `* Fixed ...`
+         - Issue/contributor before final period: `` * `fn()` now accepts ... (@user, #N). ``
+         - Get username: `gh api user --jq .login`
       
       ---
       
       ## General
       
       - R console: use `--quiet --vanilla`.
+      - Always run `air format .` after generating R code.
       - Comments explain *why*, not *what*.
 
-# use_agent() does not insert 'NA' when Description or URL is absent (#2)
+# use_agent() does not insert 'NA' when Description or URL is absent (#2, #59)
 
     Code
       writeLines(readLines(fs::path(proj_dir, "AGENTS.md")))
@@ -100,14 +105,19 @@
       5. **Implement** — minimal code to pass tests.
       6. **Refactor** — clean up, keep tests green.
       7. **Document** — document any new or changed exports.
-      8. **Verify**: `devtools::check(error_on = "warning")`. Resolve warnings, errors, and NOTEs.
-      9. **News** — add a bullet at the top of `NEWS.md` for user-facing changes.
+      8. **Verify**: Run `devtools::test(reporter = "check")`, then `devtools::check(error_on = "warning")`. Resolve warnings, errors, and NOTEs.
+      9. **News** — add bullet at top of `NEWS.md` (under dev heading):
+         - User-facing changes only. 1 line, end with `.`
+         - Present tense, positive framing, function names (backticks + `()`) near start: `` * `fn()` now accepts ... `` not `* Fixed ...`
+         - Issue/contributor before final period: `` * `fn()` now accepts ... (@user, #N). ``
+         - Get username: `gh api user --jq .login`
       
       ---
       
       ## General
       
       - R console: use `--quiet --vanilla`.
+      - Always run `air format .` after generating R code.
       - Comments explain *why*, not *what*.
 
 # use_agent() emits an informational message after writing (#2)

--- a/tests/testthat/test-use_agent.R
+++ b/tests/testthat/test-use_agent.R
@@ -8,7 +8,7 @@ test_that("use_agent() writes AGENTS.md and returns the path invisibly (#2)", {
   )
 })
 
-test_that("use_agent() substitutes Package and Title into the template (#2)", {
+test_that("use_agent() substitutes Package and Title into the template (#2, #59)", {
   proj_dir <- local_pkg()
   suppressMessages(use_agent(open = FALSE))
   expect_snapshot({
@@ -16,7 +16,7 @@ test_that("use_agent() substitutes Package and Title into the template (#2)", {
   })
 })
 
-test_that("use_agent() does not insert 'NA' when Description or URL is absent (#2)", {
+test_that("use_agent() does not insert 'NA' when Description or URL is absent (#2, #59)", {
   proj_dir <- local_pkg(
     DESCRIPTION = c(
       "Package: minpkg",


### PR DESCRIPTION
Back-port generally applicable improvements from the root AGENTS.md into inst/templates/AGENTS.md: step 8 now explicitly runs tests before check, step 9 includes detailed NEWS formatting guidance, and General adds the air format . bullet. Snapshot tests updated and tagged with #59.

Closes #59