### PR TITLE
Namespace `caller_env()`

### DIFF
--- a/inst/templates/aaa-conditions.R
+++ b/inst/templates/aaa-conditions.R
@@ -8,8 +8,8 @@
   message,
   subclass,
   parent = NULL,
-  call = caller_env(),
-  message_env = caller_env(),
+  call = rlang::caller_env(),
+  message_env = rlang::caller_env(),
   ...
 ) {
   stbl::pkg_abort(
@@ -33,8 +33,8 @@
   message,
   subclass,
   parent = NULL,
-  call = caller_env(),
-  message_env = caller_env(),
+  call = rlang::caller_env(),
+  message_env = rlang::caller_env(),
   ...
 ) {
   stbl::pkg_warn(
@@ -58,8 +58,8 @@
   message,
   subclass,
   parent = NULL,
-  call = caller_env(),
-  message_env = caller_env(),
+  call = rlang::caller_env(),
+  message_env = rlang::caller_env(),
   ...
 ) {
   stbl::pkg_inform(


### PR DESCRIPTION
Other packages don't necessarily import `rlang::caller_env()`.